### PR TITLE
エラーハンドリング調整、AWS SDKを呼び出すモジュール作成

### DIFF
--- a/app/aws/SesModules.mjs
+++ b/app/aws/SesModules.mjs
@@ -1,5 +1,3 @@
-import { ListVerifiedEmailAddressesCommand } from "@aws-sdk/client-ses";
-
 export const verifyEmailAddressSes = async ({
   sesClient,
   verifyEmailIdentityCommand,

--- a/app/aws/SesModules.mjs
+++ b/app/aws/SesModules.mjs
@@ -63,7 +63,7 @@ export const sendEmailSes = async ({ sesClient, sendEmailCommand }) => {
     });
 };
 
-export const verifyAndSendEmailSes = ({
+export const verifyAndSendEmailSes = async ({
   mailObject,
   verifyEmailIdentityCommand,
   sendEmailCommand,
@@ -84,7 +84,7 @@ export const verifyAndSendEmailSes = ({
     });
 };
 
-export const confirmVerifiedAndSendEmailSes = ({
+export const confirmVerifiedAndSendEmailSes = async ({
   mailObject,
   verifiedCheckCommand,
   verifyEmailIdentityCommand,

--- a/app/aws/SesModules.mjs
+++ b/app/aws/SesModules.mjs
@@ -2,10 +2,8 @@ import { ListVerifiedEmailAddressesCommand } from "@aws-sdk/client-ses";
 
 export const verifyEmailAddressSes = async ({
   sesClient,
-  mailAddress,
   verifyEmailIdentityCommand,
 }) => {
-  console.log(mailAddress);
   return sesClient
     .send(verifyEmailIdentityCommand)
     .then((res) => {
@@ -35,12 +33,7 @@ export const verifyEmailAddressSes = async ({
     });
 };
 
-export const sendEmailSes = async ({
-  mailObject,
-  sesClient,
-  mailAddress,
-  sendEmailCommand,
-}) => {
+export const sendEmailSes = async ({ sesClient, sendEmailCommand }) => {
   return sesClient
     .send(sendEmailCommand)
     .then((res) => {
@@ -74,15 +67,15 @@ export const verifyAndSendEmailSes = ({
   mailObject,
   verifyEmailIdentityCommand,
   sendEmailCommand,
-  ...sesSet
+  sesClient,
 }) => {
   return verifyEmailAddressSes({
     mailObject,
     verifyEmailIdentityCommand,
-    ...sesSet,
+    sesClient,
   })
     .then(() => {
-      return sendEmailSes({ mailObject, sendEmailCommand, ...sesSet });
+      return sendEmailSes({ sendEmailCommand, sesClient });
     })
     .catch((err) => {
       console.error("Failed to send email.");
@@ -96,19 +89,20 @@ export const confirmVerifiedAndSendEmailSes = ({
   verifiedCheckCommand,
   verifyEmailIdentityCommand,
   sendEmailCommand,
-  ...sesSet
+  mailAddress,
+  sesClient,
 }) => {
-  return sesSet.sesClient
+  return sesClient
     .send(verifiedCheckCommand)
     .then((res) => {
       const verifiedEmailList = res.VerifiedEmailAddresses;
-      return verifiedEmailList.includes(sesSet.mailAddress)
-        ? sendEmailSes({ mailObject, sendEmailCommand, ...sesSet })
+      return verifiedEmailList.includes(mailAddress)
+        ? sendEmailSes({ mailObject, sendEmailCommand, sesClient })
         : verifyAndSendEmailSes({
             mailObject,
             verifyEmailIdentityCommand,
             sendEmailCommand,
-            ...sesSet,
+            sesClient,
           });
     })
     .then((res) => {

--- a/app/aws/SesModules.mjs
+++ b/app/aws/SesModules.mjs
@@ -1,0 +1,134 @@
+import { ListVerifiedEmailAddressesCommand } from "@aws-sdk/client-ses";
+
+export const verifyEmailAddressSes = async ({
+  sesClient,
+  mailAddress,
+  verifyEmailIdentityCommand,
+}) => {
+  console.log(mailAddress);
+  return sesClient
+    .send(verifyEmailIdentityCommand)
+    .then((res) => {
+      console.log("Success to verify email addmin");
+      console.log(res);
+      const successRes = {
+        statusCode: 200,
+        body: {
+          errorMessage: "メールアドレス検証成功",
+        },
+      };
+      const resJson = JSON.stringify(successRes);
+      return resJson;
+    })
+    .catch((err) => {
+      console.error("Failed to send email.");
+      console.error(err);
+      const awsError = {
+        statusCode: 500,
+        body: {
+          errorMessage:
+            "メールアドレス検証に問題がありました。Lambdaのログを確認してください。",
+        },
+      };
+      const resJson = JSON.stringify(awsError);
+      throw new Error(resJson);
+    });
+};
+
+export const sendEmailSes = async ({
+  mailObject,
+  sesClient,
+  mailAddress,
+  sendEmailCommand,
+}) => {
+  return sesClient
+    .send(sendEmailCommand)
+    .then((res) => {
+      console.log("Success to send email.");
+      console.log(res);
+      const successRes = {
+        statusCode: 200,
+        body: {
+          errorMessage: "メール送信成功",
+        },
+      };
+      const resJson = JSON.stringify(successRes);
+      return resJson;
+    })
+    .catch((err) => {
+      console.error("Failed to send email.");
+      console.error(err);
+      const awsError = {
+        statusCode: 500,
+        body: {
+          errorMessage:
+            "メール送信に問題がありました。Lambdaのログを確認してください。",
+        },
+      };
+      const resJson = JSON.stringify(awsError);
+      throw new Error(resJson);
+    });
+};
+
+export const verifyAndSendEmailSes = ({
+  mailObject,
+  verifyEmailIdentityCommand,
+  sendEmailCommand,
+  ...sesSet
+}) => {
+  return verifyEmailAddressSes({
+    mailObject,
+    verifyEmailIdentityCommand,
+    ...sesSet,
+  })
+    .then(() => {
+      return sendEmailSes({ mailObject, sendEmailCommand, ...sesSet });
+    })
+    .catch((err) => {
+      console.error("Failed to send email.");
+      console.error(err);
+      return err;
+    });
+};
+
+export const confirmVerifiedAndSendEmailSes = ({
+  mailObject,
+  verifyEmailIdentityCommand,
+  sendEmailCommand,
+  ...sesSet
+}) => {
+  const verifiedCheckInput = undefined;
+  const verifiedCheckCommand = new ListVerifiedEmailAddressesCommand(
+    verifiedCheckInput
+  );
+
+  return sesSet.sesClient
+    .send(verifiedCheckCommand)
+    .then((res) => {
+      const verifiedEmailList = res.VerifiedEmailAddresses;
+      return verifiedEmailList.includes(sesSet.mailAddress)
+        ? sendEmailSes({ mailObject, sendEmailCommand, ...sesSet })
+        : verifyAndSendEmailSes({
+            mailObject,
+            verifyEmailIdentityCommand,
+            sendEmailCommand,
+            ...sesSet,
+          });
+    })
+    .then((res) => {
+      console.log("send mail complete");
+      return res;
+    })
+    .catch((err) => {
+      console.error(err);
+      const awsError = {
+        statusCode: 500,
+        body: {
+          errorMessage:
+            "メール検証済みチェックに問題がありました。Lambdaのログを確認してください。",
+        },
+      };
+      const resJson = JSON.stringify(awsError);
+      throw new Error(resJson);
+    });
+};

--- a/app/aws/SesModules.mjs
+++ b/app/aws/SesModules.mjs
@@ -93,15 +93,11 @@ export const verifyAndSendEmailSes = ({
 
 export const confirmVerifiedAndSendEmailSes = ({
   mailObject,
+  verifiedCheckCommand,
   verifyEmailIdentityCommand,
   sendEmailCommand,
   ...sesSet
 }) => {
-  const verifiedCheckInput = undefined;
-  const verifiedCheckCommand = new ListVerifiedEmailAddressesCommand(
-    verifiedCheckInput
-  );
-
   return sesSet.sesClient
     .send(verifiedCheckCommand)
     .then((res) => {

--- a/app/index.mjs
+++ b/app/index.mjs
@@ -11,6 +11,15 @@ import {
 } from "./validation.mjs";
 import { confirmVerifiedAndSendEmailSes } from "./aws/SesModules.mjs";
 
+const verifiedCheckInput = undefined;
+const verifiedCheckCommand = new ListVerifiedEmailAddressesCommand(
+  verifiedCheckInput
+);
+
+const createVerifyEmailIdentityCommand = (mailAddress) => {
+  return new VerifyEmailIdentityCommand({ EmailAddress: mailAddress });
+};
+
 const createSendEmailCommand = (toAddress, fromAddress, contentObj) => {
   return new SendEmailCommand({
     Destination: {
@@ -36,10 +45,6 @@ const createSendEmailCommand = (toAddress, fromAddress, contentObj) => {
     Source: fromAddress,
     ReplyToAddresses: [],
   });
-};
-
-const createVerifyEmailIdentityCommand = (mailAddress) => {
-  return new VerifyEmailIdentityCommand({ EmailAddress: mailAddress });
 };
 
 export const handler = (event, context, callback) => {
@@ -80,6 +85,7 @@ export const handler = (event, context, callback) => {
       console.log(data);
       return confirmVerifiedAndSendEmailSes({
         mailObject: eventClone,
+        verifiedCheckCommand,
         verifyEmailIdentityCommand,
         sendEmailCommand,
         ...sesSet,

--- a/app/index.mjs
+++ b/app/index.mjs
@@ -153,7 +153,7 @@ const confirmVerifiedAndSendEmailSes = ({ mailObject, ...sesSet }) => {
         },
       };
       const resJson = JSON.stringify(awsError);
-      return resJson;
+      throw new Error(resJson);
     });
 };
 
@@ -193,7 +193,7 @@ export const handler = (event, context, callback) => {
     .catch((err) => {
       console.error("Failure...! invalid values!");
       console.error(err);
-      callback(null, err);
+      callback(err);
       return err;
     });
 };

--- a/app/index.mjs
+++ b/app/index.mjs
@@ -61,11 +61,6 @@ export const handler = (event, context, callback) => {
 
   const emailAdmin = env.EMAIL_ADMIN;
 
-  const sesSet = {
-    sesClient,
-    mailAddress: emailAdmin,
-  };
-
   const verifyEmailIdentityCommand =
     createVerifyEmailIdentityCommand(emailAdmin);
   const sendEmailCommand = createSendEmailCommand(
@@ -88,7 +83,8 @@ export const handler = (event, context, callback) => {
         verifiedCheckCommand,
         verifyEmailIdentityCommand,
         sendEmailCommand,
-        ...sesSet,
+        mailAddress: emailAdmin,
+        sesClient,
       });
     })
     .catch((err) => {

--- a/app/index.mjs
+++ b/app/index.mjs
@@ -174,7 +174,6 @@ export const handler = (event, context, callback) => {
   const sesSet = {
     sesClient,
     mailAddress: emailAdmin,
-    callback,
   };
 
   return Promise.all([

--- a/app/index.mjs
+++ b/app/index.mjs
@@ -41,7 +41,7 @@ const createVerifyEmailIdentityCommand = (mailAddress) => {
   return new VerifyEmailIdentityCommand({ EmailAddress: mailAddress });
 };
 
-const verifyEmailAddressSes = ({ sesClient, mailAddress, callback }) => {
+const verifyEmailAddressSes = async ({ sesClient, mailAddress }) => {
   const verifyEmailIdentityCommand =
     createVerifyEmailIdentityCommand(mailAddress);
   console.log(mailAddress);
@@ -70,12 +70,11 @@ const verifyEmailAddressSes = ({ sesClient, mailAddress, callback }) => {
         },
       };
       const resJson = JSON.stringify(awsError);
-      callback(resJson);
-      return resJson;
+      throw new Error(resJson);
     });
 };
 
-const sendEmailSes = ({ mailObject, sesClient, mailAddress, callback }) => {
+const sendEmailSes = async ({ mailObject, sesClient, mailAddress }) => {
   const sendEmailCommand = createSendEmailCommand(
     mailAddress,
     mailAddress,
@@ -107,8 +106,7 @@ const sendEmailSes = ({ mailObject, sesClient, mailAddress, callback }) => {
         },
       };
       const resJson = JSON.stringify(awsError);
-      callback(resJson);
-      return resJson;
+      throw new Error(resJson);
     });
 };
 


### PR DESCRIPTION
### エラーハンドリング調整
SDKエラーを`callback`関数ではなく`throw`でエラーを投げるよう修正
非同期関数として扱うよう`async`付与
エントリポイントで`callback`を利用するよう修正したので共通オブジェクトから`callback`を除外

### AWS SDKを呼び出すモジュール作成
SDKで用意されている関数の実行のみをまとめるモジュールとして定義
現状はSESClientモジュールを主に使用している
送信するコマンドの作成、SESClientの作成はエントリポイントで制御
モジュール化の中で引数の共通化する必要がないことがわかったのでsesSet削除